### PR TITLE
Avoid console warning on title rendering multiple children

### DIFF
--- a/pages/posts/[slug].js
+++ b/pages/posts/[slug].js
@@ -24,7 +24,7 @@ function PostPage({ post }) {
   return (
     <>
       <Head>
-        <title>{post.title} - My Blog</title>
+        <title>{`${post.title}  - My Blog`}</title>
       </Head>
       <main>
         <p>{post.date}</p>


### PR DESCRIPTION
With this change it avoids the console warning message:

`Warning: A title element received an array with more than 1 element as children. In browsers title Elements can only have Text Nodes as children.`